### PR TITLE
add_host_user/preconf WIP

### DIFF
--- a/lib.d/dex-install.sh
+++ b/lib.d/dex-install.sh
@@ -56,6 +56,9 @@ dex-install(){
         declare -f __local_docker >> $bin
         declare -f __deactivate_machine >> $bin
         declare -f get_group_id >> $bin
+        declare -f preconf-container-name >> $bin
+        declare -f preconf-init-temp-dir >> $bin
+        declare -f preconf-runtime >> $bin
         declare -f $runtimeFn >> $bin
         echo "__image=\"$imgname\"" >> $bin
         echo "$runtimeFn \$@" >> $bin

--- a/lib.d/dex-install.sh
+++ b/lib.d/dex-install.sh
@@ -23,6 +23,8 @@ dex-install(){
 
   for imgname in ${__built_images[@]}; do
 
+    preconf-install $imgname
+
     local api=$(__local_docker inspect --format "{{ index .Config.Labels \"org.dockerland.dex.api\" }}" $imgname)
     local image=$(__local_docker inspect --format "{{ index .Config.Labels \"org.dockerland.dex.image\" }}" $imgname)
     local tag=$(__local_docker inspect --format "{{ index .Config.Labels \"org.dockerland.dex.build-tag\" }}" $imgname)

--- a/lib.d/helpers/preconf.sh
+++ b/lib.d/helpers/preconf.sh
@@ -4,12 +4,12 @@
 
 # usage: preconf-container-name <image name>
 preconf-container-name(){
-  echo $1"_original"
+  echo "$(echo $1 | sed 's/:.*$//' | sed 's/\//_/g')_original"
 }
 
 # usage: preconf-init-temp-dir <image name>
 preconf-init-temp-dir(){
-  local preconf_dir="$DEX_HOME/preconf_temp/$1"
+  local preconf_dir="$DEX_HOME/preconf_temp/$(echo $1| sed 's/:.*$//')"
   rm -rf $preconf_dir
   mkdir -p $preconf_dir
   echo $preconf_dir
@@ -18,8 +18,10 @@ preconf-init-temp-dir(){
 # usage: preconf-install <image name>
 preconf-install(){
     local container_name=$(preconf-container-name $1)
-    __local_docker rm --force --volumes $container_name
-    __local_docker run docker run --entrypoint=/dev/null --name $container_name $1
+    {
+      __local_docker rm --force --volumes $container_name 
+      __local_docker run --entrypoint=/dev/null --name $container_name $1
+    } &> /dev/null
 }
 
 # usage: preconf-runtime <image name>
@@ -27,8 +29,9 @@ preconf-runtime(){
     local container_name=$(preconf-container-name $1)
     local temp_dir=$(preconf-init-temp-dir $1)
     
+    mkdir -p "$temp_dir/etc/"
     passwd_file="$temp_dir/etc/passwd"
-    groups_file="$temp_dir/etc/passwd"
+    group_file="$temp_dir/etc/passwd"
 
     docker cp $container_name:/etc/passwd $passwd_file
     docker cp $container_name:/etc/group $group_file

--- a/lib.d/helpers/preconf.sh
+++ b/lib.d/helpers/preconf.sh
@@ -1,0 +1,39 @@
+#
+# lib.d/helpers/preconf.sh for dex -*- shell-script -*-
+#
+
+# usage: preconf-container-name <image name>
+preconf-container-name(){
+  echo $1"_original"
+}
+
+# usage: preconf-init-temp-dir <image name>
+preconf-init-temp-dir(){
+  local preconf_dir="$DEX_HOME/preconf_temp/$1"
+  rm -rf $preconf_dir
+  mkdir -p $preconf_dir
+  echo $preconf_dir
+}
+
+# usage: preconf-install <image name>
+preconf-install(){
+    local container_name=$(preconf-container-name $1)
+    __local_docker rm --force --volumes $container_name
+    __local_docker run docker run --entrypoint=/dev/null --name $container_name $1
+}
+
+# usage: preconf-runtime <image name>
+preconf-runtime(){
+    local container_name=$(preconf-container-name $1)
+    local temp_dir=$(preconf-init-temp-dir $1)
+    
+    passwd_file="$temp_dir/etc/passwd"
+    groups_file="$temp_dir/etc/passwd"
+
+    docker cp $container_name:/etc/passwd $passwd_file
+    docker cp $container_name:/etc/group $group_file
+
+    echo "$DEX_HOST_USER:x:$DEX_HOST_UID:$DEX_HOST_UID:fullname:/dex/home:/bin/sh" >> $passwd_file
+    echo "$DEX_HOST_GROUP:x:$DEX_HOST_GID:" >> $group_file
+}
+

--- a/lib.d/v1-runtime.sh
+++ b/lib.d/v1-runtime.sh
@@ -39,7 +39,7 @@ v1-runtime(){
   __window=
 
   # augment defaults with image meta
-  for label in api docker_devices docker_envars docker_flags docker_groups docker_home docker_workspace docker_volumes host_docker host_paths host_users window ; do
+  for label in api add_host_user docker_devices docker_envars docker_flags docker_groups docker_home docker_workspace docker_volumes host_docker host_paths host_users window ; do
     # @TODO reduce this to a single docker inspect command
     val=$(__local_docker inspect --format "{{ index .Config.Labels \"org.dockerland.dex.$label\" }}" $__image)
     [ -z "$val" ] && continue
@@ -147,7 +147,7 @@ v1-runtime(){
   # add host user and group to container's /etc/passwd and /etc/group
   case $(echo "$__add_host_user" | awk '{print tolower($0)}') in true|yes|on)
     preconf-runtime $__image
-    __docker_volumes+=" $passwd_file:/etc/passwd:$__host_users $group_file:/etc/group:$__host_users"
+    __docker_volumes+=" $passwd_file:/etc/passwd $group_file:/etc/group"
   esac
 
   # map host docker socket and passthru docker vars
@@ -167,7 +167,7 @@ v1-runtime(){
 
   # mount specified volumes (only if they exist)
   for path in $__docker_volumes; do
-    IFS=":" read path_host path_container path_mode <<<$path
+    IFS=":" read path_host path_container path_mode <<< "$path"
     path_host=${path_host/#\~/$HOME}
     [ -e "$path_host" ] || continue
     __docker_flags+=" -v $path_host:${path_container:-$path_host}:${path_mode:-rw}"

--- a/lib.d/v1-runtime.sh
+++ b/lib.d/v1-runtime.sh
@@ -11,6 +11,7 @@ v1-runtime(){
   # label defaults -- images may provide a org.dockerland.dex.<var> label
   #  supplying a value that overrides these default values, examples are:
   #
+  #  org.dockerland.dex.add_host_user=yes         (adds host user/uid and group/gid to container's /etc/passwd and /etc/group)
   #  org.dockerland.dex.docker_devices=/dev/shm   (shm mounted as /dev/shm)
   #  org.dockerland.dex.docker_envars="LANG TERM !MYAPP_" (passthru LANG & TERM & MYAPP_*)
   #  org.dockerland.dex.docker_flags=-it          (interactive tty)
@@ -23,6 +24,8 @@ v1-runtime(){
   #  org.dockerland.dex.host_users=ro             (ro mount host /etc/passwd|group)
   #  org.dockerland.dex.window=yes                (applies window/X11 flags)
   #
+
+  __add_host_user=
   __docker_devices=
   __docker_envars="LANG TZ"
   __docker_flags=
@@ -139,6 +142,12 @@ v1-runtime(){
   # map host /etc/passwd and /etc/group in container
   case $(echo "$__host_users" | awk '{print tolower($0)}') in rw|ro)
     __docker_volumes+=" /etc/passwd:/etc/passwd:$__host_users /etc/group:/etc/group:$__host_users"
+  esac
+
+  # add host user and group to container's /etc/passwd and /etc/group
+  case $(echo "$__add_host_user" | awk '{print tolower($0)}') in true|yes|on)
+    preconf-runtime $__image
+    __docker_volumes+=" $passwd_file:/etc/passwd:$__host_users $group_file:/etc/group:$__host_users"
   esac
 
   # map host docker socket and passthru docker vars


### PR DESCRIPTION
@briceburg Dirty but functional.
- `helper/preconf.sh`, with some handling for reading the original image files for editing
- Modifications to `dex-install.sh` to create the preconf container and add preconf functionality to runtime wrappers
- Modifications to `v1-runtime.sh` to support `org.dockerland.dex.add_host_user` label and mount edited passwd/group files

I'd like to: 
- Make the preconf functions rely less on variables set in other files (if that's necessary/possible)
- Make preconf more generic so it can support running arbitrary preconf code found in an additional new label (`org.dockerland.dex.preconf` maybe?)
- Include some convenient built-in preconf functions that map to simple toggle labels like `org.dockerland.dex.add_host_user` already found in this example for `passwd` and `group`.
- Add caching for changes that only need to be made at build time. Maybe have two labels, `preconf_build` and `preconf_runtime`.

Obviously this needs to get cleaned up a lot, but after spending some time familiarizing myself with how `dex` works under the hood, this at least works, and can be a starting point for expanded support for editing existing files in the image at runtime.
